### PR TITLE
Fix client method getAll to match apiRest's  response

### DIFF
--- a/src/artworks/client/ArtworksClient.ts
+++ b/src/artworks/client/ArtworksClient.ts
@@ -13,7 +13,9 @@ class ArtworksClient implements ArtworksClientStructure {
         throw new Error("Request failed! Code: " + response.status);
       }
 
-      return (await response.json()) as Artwork[];
+      const { artworks } = (await response.json()) as { artworks: Artwork[] };
+
+      return artworks;
     } catch (error) {
       throw new Error("Unable to get Artworks: " + (error as Error).message);
     }

--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -8,7 +8,6 @@ describe("Given the IconButton component", () => {
   const buttonAction = vi.fn();
   const source = "/icon/heart-icon.svg";
   const alternativeText = "red heart";
-  const className = "";
 
   describe("When it receives an image with the alternative text:'red heart'", () => {
     test("Then it should show an image with the alternative text: 'red heart'", () => {
@@ -19,7 +18,6 @@ describe("Given the IconButton component", () => {
           action={buttonAction}
           source={source}
           alternativeText={alternativeText}
-          className={className}
         />,
       );
 
@@ -38,7 +36,6 @@ describe("Given the IconButton component", () => {
           action={buttonAction}
           source={source}
           alternativeText={alternativeText}
-          className={className}
         />,
       );
 

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -3,14 +3,14 @@ import "./IconButton.scss";
 interface IconButonProps {
   source: string;
   alternativeText: string;
-  className: string;
+  className?: string;
   action: () => void;
 }
 
 const IconButton = ({
   source,
   alternativeText,
-  className,
+  className = "",
   action,
 }: IconButonProps): React.ReactElement => {
   return (

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -5,7 +5,9 @@ import { mockArtworks } from "../artworks/mocks/artworks.js";
 
 const handlers = [
   http.get(`${import.meta.env.VITE_API_URL}${routes.artworks}`, () => {
-    return HttpResponse.json<Artwork[]>(mockArtworks);
+    return HttpResponse.json<{ artworks: Artwork[] }>({
+      artworks: mockArtworks,
+    });
   }),
 ];
 

--- a/src/pages/GalleryPage/GalleryPage.tsx
+++ b/src/pages/GalleryPage/GalleryPage.tsx
@@ -44,6 +44,7 @@ const GalleryPage = (): React.ReactElement => {
         dispatch(hideLoading);
       } catch (error) {
         notify(error as Error);
+
         dispatch(hideLoading);
 
         return <EmptyGallery />;


### PR DESCRIPTION
la api de la api rest cambió: antes a las peticiones al endpoint GET /artworks respondia con un array de artowrks y ahora lo hace con un objeto con la propiedad artworks que apunta a la lista de artworks, 
se ha modificado el cleinte para que se adapte a eso. 

